### PR TITLE
Exclude coveralls from devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 node_js:
 - '0.11'
 - '0.10'
-after_success:
-- make coverage
+script: "npm run travis"
+after_success: "npm install coveralls@2.11.1 && cat ./coverage/lcov.info | coveralls"
 deploy:
   provider: npm
   email: tarmolov@gmail.com

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ run: npm
 # Build coverage
 coverage:
 	@$(NODE_MODULES_BIN)/istanbul cover $(NODE_MODULES_BIN)/_mocha tests/lib tests/examples tests/api -- --recursive $(MOCHA_FLAGS)
-	@cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
 
 # Build a new version of the library
 build:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "body-parser": "1.4.3",
     "chai": "1.9.1",
-    "coveralls": "2.11.1",
     "express": "4.2.0",
     "git-hooks": "0.0.7",
     "inherit": "2.1.0",
@@ -62,7 +61,8 @@
   ],
   "scripts": {
     "test": "make validate",
-    "prepublish": "make build"
+    "prepublish": "make build",
+    "travis": "npm test && make coverage"
   },
   "licenses": [
     {


### PR DESCRIPTION
Since coveralls is used only for travis, let's move it there. This will fix an error when running `make coverage` locally (the idea is borrowed from [express](https://github.com/strongloop/express/commit/db4a061ed6244afb2c4aa11244bbf0d694586614)) :)
