### PR TITLE
Log non ApiErrors

### DIFF
--- a/api/batch.api.js
+++ b/api/batch.api.js
@@ -1,6 +1,6 @@
 var vow = require('vow');
 
-var bla = require('../lib/index');
+var bla = require('../lib');
 
 /**
  * @typedef {Object} BatchApiMethod

--- a/examples/api/bad-method.api.js
+++ b/examples/api/bad-method.api.js
@@ -1,0 +1,12 @@
+var ApiMethod = require('../../lib/index').ApiMethod;
+
+/**
+ * The method which throws an error
+ *
+ * @see ../../tests/examples/api/bad-method.test.js Tests for the API method.
+ */
+module.exports = new ApiMethod('bad-method')
+    .setDescription('Throws an error')
+    .setAction(function () {
+        throw new Error('Oups!');
+    });

--- a/lib/api-method.js
+++ b/lib/api-method.js
@@ -121,11 +121,17 @@ var ApiMethod = inherit({
      * @returns {vow.Promise}
      */
     exec: function (params, request, api) {
-        return vow.resolve().then(function () {
+        try {
             params = params || {};
             var normalizedParams = this._normalizeParams(params, this._paramsDeclarations);
-            return this._action.call(this, normalizedParams, request, api);
-        }.bind(this));
+            return vow.cast(this._action.call(this, normalizedParams, request, api));
+        } catch (error) {
+            // notify developer about non ApiErrors
+            if (!(error instanceof ApiError)) {
+                console.error(error.stack);
+            }
+            return vow.reject(error);
+        }
     },
 
     /**

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -31,13 +31,18 @@ module.exports = function (methodPathPattern, options) {
     options = options || {};
     var api = methodPathPattern instanceof Api ? methodPathPattern : new Api(methodPathPattern);
 
-    return function (req, res) {
+    return function (req, res, next) {
         var methodName = options.buildMethodName ? options.buildMethodName(req) : req.param('method');
 
         /**
          * @param {Error} error
          */
         function showError(error) {
+            // Work only with ApiError; otherwise, proxy an error
+            if (!(error instanceof ApiError)) {
+                next(error);
+            }
+
             res.set('Content-Type', 'application/json;charset=utf-8');
             res.end(JSON.stringify({
                 error: {

--- a/tests/api/batch.test.js
+++ b/tests/api/batch.test.js
@@ -2,7 +2,8 @@ require('chai').should();
 var sinon = require('sinon');
 var expressRequest = {};
 
-var Api = require('../../lib/index').Api;
+var Api = require('../../lib').Api;
+var ApiError = require('../../lib').ApiError;
 var HelloMethod = require('../../examples/api/hello.api.js');
 var api = new Api(__dirname + '/../../examples/api/**/*.api.js');
 
@@ -56,5 +57,22 @@ describe('batch.api.js', function () {
                 HelloMethod.exec.calledOnce.should.be.true;
                 HelloMethod.exec.firstCall.calledWithExactly({name: 'Sam'}, expressRequest, api).should.be.true;
             });
+    });
+
+    describe('when non ApiError is occured', function () {
+        beforeEach(function () {
+            sinon.stub(console, 'error');
+        });
+
+        afterEach(function () {
+            console.error.restore();
+        });
+
+        it('should set INTERNAL_TYPE be default', function () {
+            return api.exec('bla-batch', {methods: [{method: 'bad-method'}]})
+                .then(function (res) {
+                    res[0].error.type.should.be.equal(ApiError.INTERNAL_ERROR);
+                });
+        });
     });
 });

--- a/tests/lib/api.test.js
+++ b/tests/lib/api.test.js
@@ -1,7 +1,9 @@
+require('chai').should();
+
 var Api = require('../../lib/api');
 var ApiMethod = require('../../lib/api-method');
 var ApiError = require('../../lib/api-error');
-var should = require('chai').should();
+var sinon = require('sinon');
 
 var api = new Api(__dirname + '/../../examples/api/**/*.api.js');
 
@@ -13,6 +15,21 @@ describe('api', function () {
 
         fn.should.throw(Error);
         fn.should.throw(ApiError);
+    });
+
+    describe('when an non ApiError is occured in a method', function () {
+        beforeEach(function () {
+            sinon.stub(console, 'error');
+        });
+
+        afterEach(function () {
+            console.error.restore();
+        });
+
+        it('should log the error', function () {
+            api.exec('bad-method');
+            console.error.calledOnce.should.be.true;
+        });
     });
 
     describe('getMethod', function () {

--- a/tests/lib/middleware.test.js
+++ b/tests/lib/middleware.test.js
@@ -151,4 +151,33 @@ describe('middleware', function (done) {
                 });
         });
     });
+
+    describe('when an non ApiError is occured', function () {
+        var nextSpy;
+
+        beforeEach(function () {
+            nextSpy = sinon.spy();
+            app = express()
+                .use(bodyParser.json())
+                .use('/api/:method?', apiMiddleware(API_FILES_PATH))
+                .use(function (err, req, res, next) {
+                    nextSpy();
+                });
+
+            sinon.stub(console, 'error');
+        });
+
+        afterEach(function () {
+            console.error.restore();
+        });
+
+        it('should proxy an error to the next middleware', function (done) {
+            request(app)
+                .post('/api/bad-method')
+                .end(function (err) {
+                    nextSpy.calledOnce.should.be.true;
+                    done(err);
+                });
+        });
+    });
 });


### PR DESCRIPTION
If you have a mistake in your API method, it won't be displayed in the terminal. I think we need to proxy all not ApiErrors.
