### PR TITLE
Warn developer if body-parse isn't executed

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -35,12 +35,10 @@ module.exports = function (methodPathPattern, options) {
         var methodName = options.buildMethodName ? options.buildMethodName(req) : req.param('method');
 
         if (!req.body) {
-            console.warn(
-                '[BLA] body-parser middleware should be executed before BLA middleware.\n',
-                '[BLA] The BLA middleware will be skipped.'
+            throw new ApiError(
+                ApiError.INTERNAL_ERROR,
+                'body-parser middleware should be executed before BLA middleware.'
             );
-            next();
-            return;
         }
 
         if (!methodName && !options.disableDocPage) {
@@ -56,7 +54,7 @@ module.exports = function (methodPathPattern, options) {
             method = api.getMethod(methodName);
 
             if (method.getOption('executeOnServerOnly')) {
-                throw new ApiError('BAD_REQUEST', 'Method can be executed only on server side');
+                throw new ApiError(ApiError.BAD_REQUEST, 'Method can be executed only on server side');
             }
         } catch (e) {
             return next();

--- a/tests/lib/middleware.test.js
+++ b/tests/lib/middleware.test.js
@@ -162,19 +162,10 @@ describe('middleware', function (done) {
     });
 
     describe('when a body-parser is missed', function () {
-        beforeEach(function () {
-            sinon.stub(console, 'warn');
-        });
-
-        afterEach(function () {
-            console.warn.restore();
-        });
-
-        it('should execute next and show warning', function (done) {
+        it('should throw an error', function (done) {
             app = express()
                 .use('/api/:method?', apiMiddleware(API_FILES_PATH))
-                .use(function () {
-                    console.warn.calledOnce.should.be.true;
+                .use(function (err, req, res, next) {
                     done();
                 });
 


### PR DESCRIPTION
Our middleware has a dependency from `body-parser`. I think it'd be great if we'll warn a developer about missed `body-parser`.
