### PR TITLE
Rename getParamsDeclarations -> getParams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ run: npm
 
 # Build coverage
 coverage:
-	$(v)$(NODE_MODULES_BIN)/istanbul cover $(NODE_MODULES_BIN)/_mocha tests/lib tests/examples tests/api -- --recursive $(MOCHA_FLAGS)
+	$(v)NO_DEPRECATION=BLA $(NODE_MODULES_BIN)/istanbul cover $(NODE_MODULES_BIN)/_mocha tests/lib tests/examples tests/api -- --recursive $(MOCHA_FLAGS)
 
 # Build a new version of the library
 build:

--- a/lib/api-method.js
+++ b/lib/api-method.js
@@ -88,8 +88,19 @@ var ApiMethod = inherit({
      *
      * @returns {Object} params Hash where each property name is a method param and value has ApiMethodParam type.
      */
-    getParamsDeclarations: function () {
+    getParams: function () {
         return this._paramsDeclarations;
+    },
+
+    /**
+     * Returns declared params.
+     *
+     * @deprecated
+     * @returns {Object} params Hash where each property name is a method param and value has ApiMethodParam type.
+     */
+    getParamsDeclarations: function () {
+        deprecate('getParamsDeclarations. Use `getParams` method instead.');
+        return this.getParams();
     },
 
     /**

--- a/lib/help-formatters/html.jade
+++ b/lib/help-formatters/html.jade
@@ -14,7 +14,7 @@ html(lang="en")
             span(class='label label-primary', style='font-size:0.5em;vertical-align:middle') server only
         p
             =method.getDescription()
-        - var params = method.getParamsDeclarations();
+        - var params = method.getParams();
         if Object.keys(params).length
           table(class='table table-bordered table-condensed')
             thead

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -80,7 +80,7 @@ module.exports = function (methodPathPattern, options) {
             return next();
         }
 
-        var declaredParams = method.getParamsDeclarations();
+        var declaredParams = method.getParams();
         var params = getParamsFromRequest(req, declaredParams);
 
         return api.exec(methodName, params, req)

--- a/tests/lib/api-method.test.js
+++ b/tests/lib/api-method.test.js
@@ -50,6 +50,7 @@ describe('api-method', function () {
             action: sinon.spy()
         });
 
+        apiMethod.getParams().testParam.should.be.eq(paramDeclaration);
         apiMethod.getParamsDeclarations().testParam.should.be.eq(paramDeclaration);
     });
 
@@ -184,8 +185,10 @@ describe('api-method', function () {
                 description: 'There is a method param'
             };
 
+            apiMethod.getParams().should.be.empty;
             apiMethod.getParamsDeclarations().should.be.empty;
             apiMethod.addParam(paramDeclaration);
+            apiMethod.getParams()[paramDeclaration.name].should.be.eq(paramDeclaration);
             apiMethod.getParamsDeclarations()[paramDeclaration.name].should.be.eq(paramDeclaration);
         });
 


### PR DESCRIPTION
Added `getParams` method and deprecated `getParamsDeclarations`.
