### PR TITLE
Use req.params instead of req.param()

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -196,7 +196,7 @@ Using the second paremeter `options` you can tune the middleware up.
 | Name                | Type     | Description                                                                                             |
 | -----------------   | -------- | ------------------------------------------------------------------------------------------------------- |
 | \[enableDocPage\]   | Boolean  | Generate documentation page. Defaults to `true`. See [example](examples/middleware/without_docpage.js). |
-| \[buildMethodName\] | Function | `express.Request` is passed to the function. The function should return a method name. By default methodName is grabbed by executing `req.param('method')`. See [example](examples/middleware/build_method_name.js). |
+| \[buildMethodName\] | Function | `express.Request` is passed to the function. The function should return a method name. By default methodName is taken from the `req.params.method`. See [example](examples/middleware/build_method_name.js). |
 
 Method parameters are `req.query` extended by `req.body`.
 

--- a/examples/middleware/build_method_name.js
+++ b/examples/middleware/build_method_name.js
@@ -10,8 +10,8 @@ var apiMiddleware = require('../../lib').apiMiddleware;
  */
 function buildMethodName(req) {
     return [
-        req.param('service'),
-        req.param('subservice')
+        req.params.service,
+        req.params.subservice
     ].filter(Boolean).join('-');
 }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -37,7 +37,7 @@ module.exports = function (methodPathPattern, options) {
     var api = methodPathPattern instanceof Api ? methodPathPattern : new Api(methodPathPattern);
 
     return function (req, res, next) {
-        var methodName = options.buildMethodName ? options.buildMethodName(req) : req.param('method');
+        var methodName = options.buildMethodName ? options.buildMethodName(req) : req.params.method;
 
         if (req.method === 'POST' && !req.body) {
             throw new ApiError(


### PR DESCRIPTION
As we know, `req.param()` is going [to be deprecated](https://github.com/strongloop/express/issues/2440), so let's take some preventive steps :)
