### PR TITLE
Add zuul support

### DIFF
--- a/.jshint-groups.js
+++ b/.jshint-groups.js
@@ -36,7 +36,7 @@ module.exports = {
                 node: true
             },
             includes: [
-                'tools/**/*.js',
+                'tools/release.js',
                 'api/**/*.js',
                 'examples/api/*.js',
                 'examples/backend/*.js',

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: node_js
 node_js:
 - '0.10'
 script: "npm run travis"
-after_success: "npm install coveralls@2.11.1 && cat ./coverage/lcov.info | coveralls"
+after_success:
+- "npm install coveralls@2.11.1 && cat ./coverage/lcov.info | coveralls"
+- "zuul -- tools/zuul.js"
 deploy:
   provider: npm
   email: tarmolov@gmail.com
@@ -11,3 +13,7 @@ deploy:
   on:
     tags: true
     all_branches: true
+env:
+  global:
+  - secure: ClEcmw33CSP8L9gATIDPjZT/QS3EBrSx2XXAXNcl6K3AXODWqjMH4uzdQJnAYaYSlPkNWLZho+L4UyF9SQJiqdUfCkGE7wlw7765w6DVztMsuupPqiA4hrTGQgbnEsbFyayrsnSLg71/Kf6MV9fyEcJZ+HtXO29BvNpuTRuji0Y=
+  - secure: O5gcZIv+clsJotxuNrCIJrFTffDfow6OnrGbhpNilurjnLLIKe7w4HFmjWVtRHmEH443LK5atC9UpBt4YAEoNEoXsAoYFbZIKi0gwZ74etJV70ttj/KrEZ7yUex7WY+mDmFqGt1wPSMkl6X3RkSVt8tOoxvCg3xhjd13AFKMHvw=

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,0 +1,19 @@
+ui: mocha-bdd
+scripts:
+  - "node_modules/chai/chai.js"
+  - "node_modules/sinon/pkg/sinon.js"
+  - "node_modules/ym/modules.js"
+  - "node_modules/vow/lib/vow.js"
+browsers:
+  - name: chrome
+    version: latest
+  - name: firefox
+    version: latest
+  - name: opera
+    version: latest
+  - name: safari
+    version: latest
+  - name: ie
+    version: 9..latest
+  - name: iphone
+    version: latest

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,14 @@ test-client:
 	$(v)echo Run client tests
 	$(v)$(NODE_MODULES_BIN)/mocha-phantomjs $(MOCHA_FLAGS) tests/blocks/run-tests.html
 
+# Run tests via zuul locally
+zuul-local:
+	$(v)$(NODE_MODULES_BIN)/zuul --local 8080 -- tools/zuul.js
+
+# Run tests via zuul in the sause cloud
+zuul:
+	$(v)$(NODE_MODULES_BIN)/zuul -- tools/zuul.js
+
 # Run server tests
 test-server:
 	$(v)echo Run server tests

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The package is versioned according to [SemVer](http://semver.org).
   * Joining all client requests into one during one tick (see [batch method](#batch)).
   * Works with the most popular module systems.
 
+## Browser support
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/baby-loris.svg)](https://saucelabs.com/u/baby-loris)
+
 ## Installation
 ```
 npm install bla --save

--- a/blocks/bla-error/bla-error.js
+++ b/blocks/bla-error/bla-error.js
@@ -64,4 +64,4 @@
         global.bla.ApiError = ApiError;
     }
 
-}(this));
+}(window));

--- a/blocks/bla/bla.js
+++ b/blocks/bla/bla.js
@@ -290,4 +290,4 @@
         global.bla.Api = createApiClass(global.vow, global.bla.ApiError);
     }
 
-}(this));
+}(window));

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "uglify-js": "2.4.15",
     "vow": "~0.4.4",
     "vow-asker": "0.6.6",
-    "ym": "0.1.0"
+    "ym": "0.1.0",
+    "zuul": "^1.13.1"
   },
   "main": "lib/index",
   "files": [

--- a/tests/blocks/bla-error/bla-error.test.js
+++ b/tests/blocks/bla-error/bla-error.test.js
@@ -12,12 +12,6 @@ modules.define('test', ['bla-error'], function (provide, ApiError) {
             error.should.be.instanceOf(ApiError);
         });
 
-        it('should have built-in error types', function () {
-            should.exist(ApiError.BAD_REQUEST);
-            should.exist(ApiError.NOT_FOUND);
-            should.exist(ApiError.INTERNAL_ERROR);
-        });
-
         it('should have a corret type', function () {
             error.type.should.be.equal('BAD_TIMES');
         });

--- a/tools/zuul.js
+++ b/tools/zuul.js
@@ -1,0 +1,10 @@
+require('../blocks/bla-error/bla-error.js');
+require('../blocks/bla/bla.js');
+require('../tests/blocks/bla/bla.test.js');
+require('../tests/blocks/bla-error/bla-error.test.js');
+
+var should = chai.should();
+window.TIMEOUT = 400; // next tick is different in browsers
+modules.require(['test'], function () {
+    mocha.run();
+});


### PR DESCRIPTION
I found [zuul tool](https://github.com/defunctzombie/zuul) which easily solves #49 issue.
However, I have must fixed our tests a little to make them passed in a sauce cloud.

Now we have browser support badge:
[![Sauce Test Status](https://saucelabs.com/browser-matrix/baby-loris.svg)](https://saucelabs.com/u/baby-loris)

Our tests don't work in IE. Probably, we should use `expect` instead of `should`. Or maybe it doesn't handle returning a promise from a test.

I need your opinions.
