### PR TITLE
Add Common JS support

### DIFF
--- a/.jshint-groups.js
+++ b/.jshint-groups.js
@@ -19,7 +19,7 @@ module.exports = {
         client: {
             options: {
                 browser: true,
-                predef: ['modules', 'define', 'require', 'bla']
+                predef: ['modules', 'define', 'require', 'bla', 'module']
             },
             includes: [
                 'blocks/**/*.js',

--- a/blocks/bla-error/bla-error.js
+++ b/blocks/bla-error/bla-error.js
@@ -59,6 +59,15 @@
         defineAsGlobal = false;
     }
 
+    /**
+     * Common JS.
+     * @see http://wiki.commonjs.org/wiki/Modules/1.1.1
+     */
+    if (typeof require === 'function' && typeof module === 'object' && typeof module.exports === 'object') {
+        module.exports = ApiError;
+        defineAsGlobal = false;
+    }
+
     if (defineAsGlobal) {
         global.bla = global.bla || {};
         global.bla.ApiError = ApiError;

--- a/blocks/bla/bla.js
+++ b/blocks/bla/bla.js
@@ -285,6 +285,17 @@
         defineAsGlobal = false;
     }
 
+    /**
+     * Common JS.
+     * @see http://wiki.commonjs.org/wiki/Modules/1.1.1
+     */
+    if (typeof require === 'function' && typeof module === 'object' && typeof module.exports === 'object') {
+        var vow = require('vow');
+        var ApiError = require('../bla-error/bla-error.js');
+        module.exports = createApiClass(vow, ApiError);
+        defineAsGlobal = false;
+    }
+
     if (defineAsGlobal) {
         global.bla = global.bla || {};
         global.bla.Api = createApiClass(global.vow, global.bla.ApiError);


### PR DESCRIPTION
Support for Common JS modules.
As for the webpack and browserify, they don't add its variables to the window object, so we can't call something like `window.require`.
The `typeof` operator allows to have undeclared variables as operands, so the if-statements seem to be safe.