### PR TITLE
Allow default params for client-side requests

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -289,6 +289,7 @@ Also you can specify extra options:
 | Name               | Type    | Description                                                                             |
 | ------------------ | ------- | --------------------------------------------------------------------------------------- |
 | \[enableBatching\] | Boolean | Configure [batching](README.md#batch) globally. Pass `false` to disable. Defaults to `true`. |
+| \[defaultParams\]  | Object  | Params that will be added to every request.                                                  |
 
 You can use the client-side bundle of bla with different module systems. For example:
 ```javascript
@@ -305,10 +306,16 @@ require(['bla'], function (Api) {
 // without module system
 var api = new bla.Api('/api/');
 ```
+
 Disable batching globally:
 ```javascript
 // all api.exec() calls will NOT be batched
 var api = new Api('/api/', {enableBatching: false});
+```
+
+Specify default params:
+```javascript
+var api = new Api('/api/', {defaultParams: {csrfToken: csrfToken}});
 ```
 
 ### exec(methodName, [params], [execOptions])


### PR DESCRIPTION
Sometimes it is necessary to pass params with every request. It works this way: no matter whether the request is batched or not, the default params are always added to the request itself. Which means, that when the request is batched, api method handlers won't receive these params. Otherwise they will.

This is useful if you want to access these params somewhere in the express middleware, but not in the api method handlers. In my case this is the csrf token.