### PR TITLE
Add toJSON method to ApiError

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,6 +7,8 @@
       * [constructor(method)](#constructormethod)
       * [exec([params], [request], [api])](#execparams-request-api)
     * [Class ApiError](#class-apierror)
+      * [constructor(type, message)](#constructortype-message)
+      * [toJson](#tojson)
       * [Error types](#error-types)
     * [Express middleware](#express-middleware)
   * Frontend side
@@ -210,6 +212,27 @@ Example:
 ```javascript
 var ApiError = require('bla').ApiError;
 throw new ApiError(ApiError.INTERNAL_ERROR, 'Internal server error');
+```
+
+### toJson()
+Stringify an ApiError into a json object. It's used by [middleware](#express-middleware).
+
+You can specify your own `toJson` implementation if you want to pass extra parameters to the client side.
+```javascript
+var apiMethod = new bla.ApiMethod({
+    name: 'method',
+    action: function () {
+        return vow.reject({
+            toJson: function () {
+                return {
+                    type: 'BAD_ERROR',
+                    message: 'Something bad is happened',
+                    reason: 'It was Loki\'s fail'
+                };
+            }
+        });
+    }
+});
 ```
 
 ### Error types

--- a/lib/api-error.js
+++ b/lib/api-error.js
@@ -13,6 +13,17 @@ var ApiError = inherit(Error, {
         this.message = message;
 
         Error.captureStackTrace(this, this.constructor);
+    },
+
+    /**
+     * @returns {Object}
+     */
+    toJson: function () {
+        var error = this;
+        return Object.keys(error).reduce(function (result, key) {
+            result[key] = error[key];
+            return result;
+        }, {});
     }
 }, {
     /**

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -51,10 +51,12 @@ module.exports = function (api, options) {
             })
             .fail(function (error) {
                 res.json({
-                    error: {
-                        type: error.type || ApiError.INTERNAL_ERROR,
-                        message: error.message
-                    }
+                    error: error.toJson ?
+                        error.toJson() :
+                        {
+                            type: error.type || ApiError.INTERNAL_ERROR,
+                            message: error.message
+                        }
                 });
             });
     };

--- a/tests/lib/api-error.test.js
+++ b/tests/lib/api-error.test.js
@@ -35,4 +35,12 @@ describe('api-error', function () {
         fn.should.throw(Error);
         fn.should.throw(ApiError);
     });
+
+    it('should stringify into json', function () {
+        error.toJson().should.deep.equal({
+            message: 'Something bad just happened',
+            name: 'ApiError',
+            type: 'BAD_TIMES'
+        });
+    });
 });

--- a/tests/lib/middleware.test.js
+++ b/tests/lib/middleware.test.js
@@ -42,7 +42,7 @@ describe('middleware', function (done) {
         request(app)
             .post('/api/hello')
             .expect('Content-Type', /json/)
-            .expect('{"error":{"type":"BAD_REQUEST","message":"missing name parameter"}}')
+            .expect('{"error":{"name":"ApiError","type":"BAD_REQUEST","message":"missing name parameter"}}')
             .expect(200)
             .end(done);
     });


### PR DESCRIPTION
Sometimes a developer need to pass an extra information with an error (not only `type` and `message`).